### PR TITLE
Demo forcing time out on PR

### DIFF
--- a/.github/workflows/boost-brakeman.yml
+++ b/.github/workflows/boost-brakeman.yml
@@ -24,3 +24,5 @@ jobs:
         with:
           api_token: ${{ secrets.BOOST_API_TOKEN }}
           registry_module: boostsecurityio/brakeman
+          pre_scan_cmd: sleep 125
+#          scan_timeout: 120 # Default value is 120 seconds


### PR DESCRIPTION
This adds a `pre_scan_cmd` which will sleep for 125 seconds, effectively guaranteeing a timeout when left at the default value of 120 seconds